### PR TITLE
Fixed sum of background level

### DIFF
--- a/lc_pulse_avalanche/avalanche.py
+++ b/lc_pulse_avalanche/avalanche.py
@@ -249,15 +249,20 @@ class LC(object):
         
         self._peak_value = self._max_raw_pcr * self._ampl
         
-        # lc from avalanche scaled + Poissonian bg added
-        if self._with_bg: # with background
-            self._plot_lc = self._raw_lc * self._ampl * self._eff_area + np.random.default_rng().poisson((self._bg), self._n)
-            #self._err_lc  = np.sqrt(self._plot_lc)
-        else: # without background
-            self._plot_lc = self._raw_lc * self._ampl * self._eff_area + np.random.default_rng().poisson((self._bg), self._n)
-            #self._err_lc  = np.sqrt(self._plot_lc)
-            self._plot_lc = self._plot_lc - self._bg
 
+        # lc from avalanche scaled + Poissonian bg added
+        # Here, contrary to what happens in the method `restore_lc()` and thus
+        # in the method `plot_lc` of the object LC, the variable `_plot_lc`` 
+        # contains the COUNTS (and not the count RATES!)
+        if self._with_bg:
+            self._plot_lc = (self._raw_lc * self._ampl * self._eff_area) + self._bg # total count rates (signal+bkg)
+            self._plot_lc = np.random.poisson( self._res * self._plot_lc )          # total count (signal+bkg) with Poisson
+            self._err_lc  = np.sqrt(self._plot_lc)
+        else: # background-subtracted
+            self._plot_lc = (self._raw_lc * self._ampl * self._eff_area) + self._bg # total count rates (signal+bkg)
+            self._plot_lc = np.random.poisson( self._res * self._plot_lc )          # total count (signal+bkg) with Poisson
+            self._err_lc  = np.sqrt(self._plot_lc)
+            self._plot_lc = self._plot_lc - (self._bg*self._res)                    # total count rates (signal) with Poisson
 
         self._get_lc_properties()
         
@@ -395,7 +400,8 @@ class LC(object):
     
     
     def _restore_lc(self):
-        """Restores GRB LC from avalanche parameters"""
+        """Restores GRB LC from avalanche parameters.
+        Here we are plotting the count RATES, not the counts!"""
         
         self._raw_lc = np.zeros(len(self._times))
         
@@ -407,13 +413,14 @@ class LC(object):
             self._raw_lc += self.norris_pulse(norm, t_delay, tau, tau_r) #
 
         if self._with_bg:
-            self._plot_lc = self._raw_lc * self._ampl * self._eff_area + np.random.default_rng().poisson((self._bg), self._n)
-            #self._plot_lc = self._raw_lc *             self._eff_area + np.random.default_rng().poisson((self._bg), self._n)
+            self._plot_lc = (self._raw_lc * self._ampl * self._eff_area) + self._bg # total count rates (signal+bkg)
+            self._plot_lc = np.random.poisson( self._res * self._plot_lc )          # total count (signal+bkg) with Poisson
+            self._plot_lc = self._plot_lc / self._res                               # total count rates (signal+bkg) with Poisson
         else:
-            self._plot_lc = self._raw_lc * self._ampl * self._eff_area + np.random.default_rng().poisson((self._bg), self._n)
-            #self._plot_lc = self._raw_lc *             self._eff_area + np.random.default_rng().poisson((self._bg), self._n)
-            self._plot_lc = self._plot_lc - self._bg
-
+            self._plot_lc = (self._raw_lc * self._ampl * self._eff_area) + self._bg # total count rates (signal+bkg)
+            self._plot_lc = np.random.poisson( self._res * self._plot_lc )          # total count (signal+bkg) with Poisson
+            self._plot_lc = self._plot_lc / self._res                               # total count rates (signal+bkg) with Poisson
+            self._plot_lc = self._plot_lc - self._bg                                # total count rates (signal) with Poisson
 
         self._get_lc_properties()
         


### PR DESCRIPTION
Fixed sum of background: the LCs generated by the code before were in count RATES, not in counts! However, in order to apply the Poisson noise after summing the constant background (and to estimate the error as the square root), we first have to convert the the count rates into COUNTS (just multiply them by the bin time (self._res)), since the Poisson statistics works with counts.